### PR TITLE
Fix uninitialized constant error in Rails 4

### DIFF
--- a/lib/my_zipcode_gem.rb
+++ b/lib/my_zipcode_gem.rb
@@ -1,3 +1,4 @@
+require 'rails/generators/actions'
 require 'rails/generators/base'
 
 module MyZipcodeGem


### PR DESCRIPTION
Under Rails 4, directly requiring `rails/generators/base` without first requiring `rails/generators/actions` results in an `uninitialized constant Rails::Generators::Actions` error from railties. This fixes that problem.