### PR TITLE
Uncomment `create_migration` method

### DIFF
--- a/lib/generators/my_zipcode_gem/models_generator.rb
+++ b/lib/generators/my_zipcode_gem/models_generator.rb
@@ -34,7 +34,8 @@ module MyZipcodeGem
     end
 
     def create_zipcode_migration
-     migration_template 'migration.rb', "db/migrate/create_my_zipcode_gem_models.rb"
+      destination_file = "db/migrate/create_my_zipcode_gem_models.rb"
+      migration_template "migration.rb", destination_file
     end
 
     def create_rakefile

--- a/lib/generators/my_zipcode_gem/models_generator.rb
+++ b/lib/generators/my_zipcode_gem/models_generator.rb
@@ -33,9 +33,9 @@ module MyZipcodeGem
       end
     end
 
-    # def create_migration
-    #  migration_template 'migration.rb', "db/migrate/create_my_zipcode_gem_models.rb"
-    # end
+    def create_zipcode_migration
+     migration_template 'migration.rb', "db/migrate/create_my_zipcode_gem_models.rb"
+    end
 
     def create_rakefile
       template 'zipcodes.rake', "lib/tasks/zipcodes.rake"


### PR DESCRIPTION
Uncomment `create_migration` code but rename method
for Rails 4 compatibility since `create_migration` is reserved